### PR TITLE
Set Fluentd dependency

### DIFF
--- a/fluent-plugin-sakuraio.gemspec
+++ b/fluent-plugin-sakuraio.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'eventmachine'
   spec.add_runtime_dependency 'faye-websocket'
-  spec.add_runtime_dependency 'fluentd'
+  spec.add_runtime_dependency 'fluentd', '>= 0.14', '< 2'
   spec.add_runtime_dependency 'yajl-ruby'
   spec.add_development_dependency 'bundler', '~> 1.13'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Because this plugin supports Fluentd v0.14.x only, does not support v0.12.x.
Fluentd v1 will be compatible with v0.14.x.
Fluentd v2 may not be compatible with v1 and v0.14.x few years later.

This is useful for users to understand that this plugin supports
Fluentd v0.14.x only.