### PR TITLE
Fix library path

### DIFF
--- a/lib/fluent/plugin/in_sakuraio.rb
+++ b/lib/fluent/plugin/in_sakuraio.rb
@@ -1,4 +1,4 @@
-require 'fluent/input'
+require 'fluent/plugin/input'
 require 'yajl'
 require 'faye/websocket'
 require 'eventmachine'


### PR DESCRIPTION
Because "fluent/input" is compatibility layer for the plugin using
Fluentd v0.12 APIs.