### PR TITLE
Use secret parameter

### DIFF
--- a/lib/fluent/plugin/in_sakuraio.rb
+++ b/lib/fluent/plugin/in_sakuraio.rb
@@ -9,7 +9,7 @@ module Fluent::Plugin
 
     helpers :thread
 
-    config_param :url, :string, default: nil
+    config_param :url, :string, default: nil, secret: true
 
     def configure(conf)
       super


### PR DESCRIPTION
This masks url parameter on boot like following:

    $ bundle exec fluentd -c f.conf
    2017-11-02 10:21:13 +0900 [info]: parsing config file is succeeded path="f.conf"
    2017-11-02 10:21:13 +0900 [info]: using configuration file: <ROOT>
      <source>
        @type sakuraio
        url xxxxxx
      </source>
      <match **>
        @type stdout
      </match>
    </ROOT>

This is useful for users to copy and paste boot log to issues.